### PR TITLE
Add email confirmation field to TaxonomicForm; update email validatio…

### DIFF
--- a/src/components/general/FormComponents/TaxonomicForm.tsx
+++ b/src/components/general/FormComponents/TaxonomicForm.tsx
@@ -137,10 +137,16 @@ const TaxonomicForm = () => {
 
                                                             const form = e.currentTarget as HTMLFormElement;
                                                             const email = form.elements.namedItem('email') as HTMLInputElement;
+                                                            const emailConfirm = form.elements.namedItem('emailConfirm') as HTMLInputElement;
                                                             const emailValue = email.value.trim();
+                                                            const emailConfirmValue = emailConfirm.value.trim();
                                                             const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue);
                                                             if (!emailValid) {
-                                                                setLoginError('Invalid email or password.');
+                                                                setLoginError('Invalid email.');
+                                                                return;
+                                                            }
+                                                            if (emailValue !== emailConfirmValue) {
+                                                                setLoginError('Email addresses do not match.');
                                                                 return;
                                                             }
                                                             const exist = await checkIfEmailExists(emailValue);
@@ -160,6 +166,16 @@ const TaxonomicForm = () => {
                                                         <div className="mb-3">
                                                             <label htmlFor="email" className="form-label">Email address</label>
                                                             <input type="email" className={`form-control${loginError ? ' is-invalid' : ''}`} id="email" name="email" required />
+                                                        </div>
+                                                        <div className="mb-3">
+                                                            <label htmlFor="emailConfirm" className="form-label">Confirm Email address</label>
+                                                            <input
+                                                                type="email"
+                                                                className={`form-control${loginError ? ' is-invalid' : ''}`}
+                                                                id="emailConfirm"
+                                                                name="emailConfirm"
+                                                                required
+                                                            />
                                                         </div>
                                                         <button type="submit" className="btn btn-primary mt-2">
                                                             {'Register'}

--- a/src/sources/forms/TaxonomicExpertForm.json
+++ b/src/sources/forms/TaxonomicExpertForm.json
@@ -22,7 +22,8 @@
                 "jsonPath": "$['schema:person']['schema:headline']",
                 "title": "Headline description",
                 "description": "A description of your job role or what you are an expert in. For example: Expert on Bee Taxonomy; Professor of Entomology, Citizen scientist on butterfly monitoring).",
-                "type": "text",
+                "type": "string",
+                "maxChars": 50,
                 "required": true
             },
             {
@@ -409,7 +410,8 @@
                 "jsonPath": "$['schema:person']['schema:biography']",
                 "title": "Expertise biography",
                 "description": "A brief description of your expertise, skills and services.",
-                "type": "text",
+                "type": "string",
+                "maxChars": 200,
                 "required": false
             },
             {

--- a/src/sources/forms/TaxonomicExpertFormOrcid.json
+++ b/src/sources/forms/TaxonomicExpertFormOrcid.json
@@ -22,7 +22,8 @@
                 "jsonPath": "$['schema:person']['schema:headline']",
                 "title": "Headline description",
                 "description": "A description of your job role or what you are an expert in. For example: Expert on Bee Taxonomy; Professor of Entomology, Citizen scientist on butterfly monitoring).",
-                "type": "text",
+                "type": "string",
+                "maxChars": 50,
                 "required": true
             },
             {
@@ -409,7 +410,8 @@
                 "jsonPath": "$['schema:person']['schema:biography']",
                 "title": "Expertise biography",
                 "description": "A brief description of your expertise, skills and services.",
-                "type": "text",
+                "type": "string",
+                "maxChars": 200,
                 "required": false
             },
             {


### PR DESCRIPTION
This pull request introduces enhancements to the `TaxonomicForm` component and updates the `TaxonomicExpertForm` and `TaxonomicExpertFormOrcid` schemas. The most notable changes include adding email confirmation functionality in the registration form and limiting the character count for specific fields in the expert forms.

### Enhancements to `TaxonomicForm`:

* Added an email confirmation input field to the form, requiring users to confirm their email address. Validation ensures the two email fields match, and appropriate error messages are displayed for mismatches or invalid email formats. (`src/components/general/FormComponents/TaxonomicForm.tsx`, [[1]](diffhunk://#diff-8825b5dcac553a9f8335f8bed7946f59b82ab280f75f8ee4bdc2783379f6f08cR140-R149) [[2]](diffhunk://#diff-8825b5dcac553a9f8335f8bed7946f59b82ab280f75f8ee4bdc2783379f6f08cR170-R179)

### Updates to `TaxonomicExpertForm` and `TaxonomicExpertFormOrcid` schemas:

* Changed the `type` of the "Headline description" field from `text` to `string` and added a `maxChars` limit of 50 characters. (`src/sources/forms/TaxonomicExpertForm.json`, [[1]](diffhunk://#diff-b2f2097ca381a34a9470145bd4277f7f5f93906df7f3784b85dc6c9a79524549L25-R26); `src/sources/forms/TaxonomicExpertFormOrcid.json`, [[2]](diffhunk://#diff-efe50399dec8f00000558bebb65175b018574bb6f88ac6b7cb7f604f4a7a70a3L25-R26)
* Changed the `type` of the "Expertise biography" field from `text` to `string` and added a `maxChars` limit of 200 characters. (`src/sources/forms/TaxonomicExpertForm.json`, [[1]](diffhunk://#diff-b2f2097ca381a34a9470145bd4277f7f5f93906df7f3784b85dc6c9a79524549L412-R414); `src/sources/forms/TaxonomicExpertFormOrcid.json`, [[2]](diffhunk://#diff-efe50399dec8f00000558bebb65175b018574bb6f88ac6b7cb7f604f4a7a70a3L412-R414)