### PR TITLE
Dest form update

### DIFF
--- a/src/components/taxonomicExpert/components/TrainingBlock.tsx
+++ b/src/components/taxonomicExpert/components/TrainingBlock.tsx
@@ -88,12 +88,16 @@ function TrainingCard({ data }: { readonly data: any }) {
                     )}
                 </Card.Text>
                 <div className="fs-4 fw-bold d-flex justify-content-between m-3">
-                    <Card.Link href={url} target="_blank" rel="noopener noreferrer" className="d-flex align-items-center">
-                        <i className="bi bi-link-45deg me-2"></i> URL
-                    </Card.Link>
-                    <Card.Link href={availableThrough} target="_blank" rel="noopener noreferrer" className="d-flex align-items-center">
-                        <i className="bi bi-link-45deg me-2"></i> Available through DEST
-                    </Card.Link>
+                    {typeof url === 'string' && url.trim() !== '' && (
+                        <Card.Link href={url} target="_blank" rel="noopener noreferrer" className="d-flex align-items-center">
+                            <i className="bi bi-link-45deg me-2"></i> URL
+                        </Card.Link>
+                    )}
+                    {typeof availableThrough === 'string' && availableThrough.trim() !== '' && (
+                        <Card.Link href={availableThrough} target="_blank" rel="noopener noreferrer" className="d-flex align-items-center">
+                            <i className="bi bi-link-45deg me-2"></i> Available through DEST
+                        </Card.Link>
+                    )}
                 </div>
             </Card.Body>
         </Card>

--- a/src/sources/forms/TaxonomicExpertForm.json
+++ b/src/sources/forms/TaxonomicExpertForm.json
@@ -753,7 +753,7 @@
             {
                 "jsonPath": "$['schema:educationAndTrainingProvision']['index']['schema:EducationalOccupationalProgram']",
                 "title": "DEST URL",
-                "description": "The URL of the training course",
+                "description": "The URL of the training course, DEST is a platform for promoting and advertising training courses in taxonomy across Europe.",
                 "type": "string",
                 "required": false
             }

--- a/src/sources/forms/TaxonomicExpertFormOrcid.json
+++ b/src/sources/forms/TaxonomicExpertFormOrcid.json
@@ -753,7 +753,7 @@
             {
                 "jsonPath": "$['schema:educationAndTrainingProvision']['index']['schema:EducationalOccupationalProgram']",
                 "title": "DEST URL",
-                "description": "The URL of the training course",
+                "description": "The URL of the training course, DEST is a platform for promoting and advertising training courses in taxonomy across Europe.",
                 "type": "string",
                 "required": false
             }


### PR DESCRIPTION
This pull request improves the display and documentation of training course URLs, particularly those associated with the DEST platform, in the taxonomic expert components and related forms. The changes ensure that URLs are only shown if they are valid, and clarify the purpose of the DEST URL field for users.

Display logic improvements:

* Updated `TrainingBlock.tsx` to conditionally render the `url` and `availableThrough` links only if they are non-empty strings, preventing empty or invalid links from appearing in the UI.

Form documentation enhancements:

* Updated the `description` for the "DEST URL" field in both `TaxonomicExpertForm.json` and `TaxonomicExpertFormOrcid.json` to explain that DEST is a platform for promoting and advertising training courses in taxonomy across Europe. [[1]](diffhunk://#diff-b2f2097ca381a34a9470145bd4277f7f5f93906df7f3784b85dc6c9a79524549L756-R756) [[2]](diffhunk://#diff-efe50399dec8f00000558bebb65175b018574bb6f88ac6b7cb7f604f4a7a70a3L756-R756)